### PR TITLE
fix(CLOUDMKAAS-1066): make volume deletion idempotent on not found

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ BINARY := bin/ec-csi-plugin
 
 build:
 	GOOS=$(GOOS) GOARCH=$(ARCH) CGO_ENABLED=0 \
-	go build -o $(BINARY) ./cmd/ec-csi-plugin
+	go build -o $(BINARY) ./cmd/main.go
 
 image-build: build
 	docker build \

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module ec-csi-plugin
 go 1.24.0
 
 require (
-	github.com/Edge-Center/edgecentercloud-go/v2 v2.1.4
+	github.com/Edge-Center/edgecentercloud-go/v2 v2.5.6
 	github.com/container-storage-interface/spec v1.11.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/sirupsen/logrus v1.9.3

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,9 @@
 github.com/Edge-Center/edgecentercloud-go/v2 v2.1.4 h1:Mug2U6n0pkI/wuR98fuLPdtN6pCReH25SJPYYuUTO9g=
 github.com/Edge-Center/edgecentercloud-go/v2 v2.1.4/go.mod h1:ukw29nT+EKFe+qrPsInTwE9Ok35KC0hUnZ3bKwfIEcg=
+github.com/Edge-Center/edgecentercloud-go/v2 v2.5.5 h1:6b8uo/AAi9PVx2CKxFws1HJFVFe2V84qhUrJHwO11Kg=
+github.com/Edge-Center/edgecentercloud-go/v2 v2.5.5/go.mod h1:aLN+G5rA8umwnIJ5U+f/cWNWdhhFRgWY0DZ6VyFXT6M=
+github.com/Edge-Center/edgecentercloud-go/v2 v2.5.6 h1:ObL/gP7sjY4/0qV0dH0RULRwnk9AZVPxs16CzPgf+IQ=
+github.com/Edge-Center/edgecentercloud-go/v2 v2.5.6/go.mod h1:aLN+G5rA8umwnIJ5U+f/cWNWdhhFRgWY0DZ6VyFXT6M=
 github.com/avast/retry-go/v4 v4.6.0 h1:K9xNA+KeB8HHc2aWFuLb25Offp+0iVRXEvFx8IinRJA=
 github.com/avast/retry-go/v4 v4.6.0/go.mod h1:gvWlPhBVsvBbLkVGDg/KwvBv0bEkCOLRRSHKIr2PyOE=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/pkg/controller/functions.go
+++ b/pkg/controller/functions.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 	"strings"
+	"time"
 
 	edgecloudV2 "github.com/Edge-Center/edgecentercloud-go/v2"
 	"github.com/Edge-Center/edgecentercloud-go/v2/util"
@@ -14,6 +15,8 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
+
+const deleteVolumeTimeout = 25 * time.Second
 
 // CreateVolume creates a new volume from the given request. The function is idempotent.
 func (s *Service) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest) (*csi.CreateVolumeResponse, error) {
@@ -118,7 +121,7 @@ func (s *Service) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequest
 	})
 	log.Infof("%s is called", methodName)
 
-	if err := util.DeleteResourceIfExist(ctx, s.cloud, s.cloud.Volumes, req.VolumeId); err != nil {
+	if err := util.DeleteResourceIfExist(ctx, s.cloud, s.cloud.Volumes, req.VolumeId, deleteVolumeTimeout); err != nil {
 		return nil, status.Errorf(codes.Internal, "%s: volume was not deleted with error %v", methodName, err)
 	}
 	log.Info("volume is deleted")

--- a/pkg/controller/resources.go
+++ b/pkg/controller/resources.go
@@ -54,33 +54,45 @@ func (s *Service) ensureAttachmentVolume(ctx context.Context, volumeID, instance
 	if err != nil {
 		return "", err
 	}
+
 	if !exist {
-		return "", errors.New("not found")
+		return "", errors.New("volume not found")
 	}
 
 	exist, err = util.ResourceIsExist(ctx, s.cloud.Instances.Get, instanceID)
 	if err != nil {
 		return "", err
 	}
+
 	if !exist {
-		return "", errors.New("not found")
+		return "", errors.New("instance not found")
 	}
 
 	vol, _, err := s.cloud.Volumes.Get(ctx, volumeID)
 	if err != nil {
 		return "", err
 	}
-	if len(vol.Attachments) != 0 {
-		if vol.Attachments[0].ServerID == instanceID {
-			return "", nil
+
+	if len(vol.Attachments) > 0 {
+		attachment := vol.Attachments[0]
+
+		if attachment.ServerID == instanceID {
+			return attachment.Device, nil
 		}
-		return "", errors.New("volume attach to different node")
+
+		return "", fmt.Errorf("volume %q already attached to different node: %q",
+			volumeID,
+			attachment.ServerID,
+		)
 	}
 
-	_, _, err = s.cloud.Volumes.Attach(ctx, volumeID, &edgecloudV2.VolumeAttachRequest{InstanceID: instanceID})
+	_, _, err = s.cloud.Volumes.Attach(ctx, volumeID, &edgecloudV2.VolumeAttachRequest{
+		InstanceID: instanceID,
+	})
 	if err != nil {
 		return "", err
 	}
+
 	if err = util.WaitVolumeAttachedToInstance(ctx, s.cloud, volumeID, instanceID, nil); err != nil {
 		return "", err
 	}
@@ -89,20 +101,30 @@ func (s *Service) ensureAttachmentVolume(ctx context.Context, volumeID, instance
 	if err != nil {
 		return "", err
 	}
+
 	if vol.Status != "in-use" {
-		return "", fmt.Errorf("cannot get device path of volume %s, its status is %s ", vol.Name, vol.Status)
+		return "", fmt.Errorf("cannot get device path of volume %s, its status is %s",
+			vol.Name,
+			vol.Status,
+		)
 	}
 
-	var devicePath string
-	if len(vol.Attachments) > 0 && vol.Attachments[0].ServerID != "" {
-		if instanceID == vol.Attachments[0].ServerID {
-			devicePath = vol.Attachments[0].Device
+	if len(vol.Attachments) > 0 {
+		attachment := vol.Attachments[0]
+
+		if attachment.ServerID == instanceID {
+			return attachment.Device, nil
 		}
-		return "", fmt.Errorf("[ControllerPublishVolume] disk %q is attached to a different compute: %q, should be detached before proceeding",
-			vol.ID, vol.Attachments[0].ServerID)
+
+		return "", fmt.Errorf("[ControllerPublishVolume] disk %q is attached to a different compute: %q",
+			vol.ID,
+			attachment.ServerID,
+		)
 	}
-	return devicePath, nil
+
+	return "", fmt.Errorf("volume %q attached but no attachment info returned", volumeID)
 }
+
 func (s *Service) ensureDetachmentVolume(ctx context.Context, volumeID, instanceID string) error {
 	vol, resp, err := s.cloud.Volumes.Get(ctx, volumeID)
 	if resp != nil && resp.StatusCode == http.StatusNotFound {


### PR DESCRIPTION
Описание

Исправлена логика работы с volume в CSI (attach и delete), добавлена идемпотентность и защита от лишних retry.

---

Изменения в ensureAttachmentVolume

Проблема

При создании PVC возникала ошибка:

```
[2026-05-06 09:26:40] time="2026-05-06T06:26:40Z" level=error msg="call /csi.v1.Controller/ControllerPublishVolume with error: rpc error: code = Internal desc = ControllerPublishVolume: cannot attach volume: [ControllerPublishVolume] disk \"4bef2aa1-60a4-4306-99a5-cf2a791942fb\" is attached to a different compute: \"0f1bb9a1-06ac-4911-a581-24a7a2f8f963\", should be detached before proceeding"
```

Хотя volume уже был подключён к той же ноде.

Причина

* Логика не была идемпотентной
* При уже существующем attachment:

  * возвращался пустой devicePath
  * либо возвращалась ошибка, даже если volume подключён к нужной ноде

Решение

* Если volume уже подключён к текущей ноде — возвращается существующий devicePath
* Исключена повторная попытка attach
* Исправлена обработка случая "already attached"

Результат

* ControllerPublishVolume стал идемпотентным
* Убраны лишние retry со стороны Kubernetes
* Более стабильное создание PVC и запуск pod’ов

---

Изменения в DeleteVolume

Проблема

Если volume уже удалён, CSI:

* продолжал вызывать delete
* получал 404
* бесконечно ретраил
* создавал лишнюю нагрузку на cloud API

Решение

* 404 (NotFound) теперь считается успешным удалением
* Добавлен timeout для операции удаления:

```
deleteVolumeTimeout = 25 * time.Second
```

Зачем timeout

* не блокировать CSI на долгих или зависших операциях удаления
* быстрее отдавать управление Kubernetes
* снизить нагрузку на cloud API при retry

Результат

* удаление стало идемпотентным
* устранены бесконечные retry
* более стабильная работа CSI

---

Итог

* Attach и Delete теперь идемпотентны
* Убраны race condition и ложные ошибки
* Снижена нагрузка на cloud API
* Поведение CSI стало предсказуемым и стабильным
